### PR TITLE
SRE-3205 ci: Update for Fedora 42

### DIFF
--- a/packaging/Dockerfile.mockbuild
+++ b/packaging/Dockerfile.mockbuild
@@ -26,9 +26,9 @@ RUN chmod +x /tmp/repo-helper.sh &&                 \
     rm -f /tmp/repo-helper.sh
 
 # Install basic tools
-RUN dnf -y install mock make                                        \
-                   rpm-build createrepo rpmlint redhat-lsb-core git \
-                   python-srpm-macros rpmdevtools &&                \
+RUN dnf -y install mock make                         \
+                   rpm-build createrepo rpmlint git  \
+                   python-srpm-macros rpmdevtools && \
     dnf -y clean all
 
 # use same UID as host and default value of 1000 if not specified

--- a/packaging/scripts/repo-helper-fedora.sh
+++ b/packaging/scripts/repo-helper-fedora.sh
@@ -10,7 +10,11 @@ set -uex
 : "${REPOSITORY_NAME:=artifactory}"
 : "${archive:=}"
 if [ "$FVERSION" != "latest" ]; then
-    archive="-archive"
+    if [ "$FVERSION" != "42" ]; then
+        if [ "$FVERSION" != "41" ]; then
+            archive="-archive"
+        fi
+    fi
 fi
 
 # shellcheck disable=SC2120
@@ -62,7 +66,7 @@ if [ -n "$REPO_FILE_URL" ]; then
     pushd /etc/yum.repos.d/
     curl -k --noproxy '*' -sSf                                  \
          -o "daos_ci-fedora${archive}-${REPOSITORY_NAME}.repo"  \
-         "{$REPO_FILE_URL}daos_ci-fedora${archive}-${REPOSITORY_NAME}.repo"
+         "${REPO_FILE_URL}daos_ci-fedora${archive}-${REPOSITORY_NAME}.repo"
     disable_repos /etc/yum.repos.d/
     popd
 fi


### PR DESCRIPTION
- redhat-lsb-core no longer supported by Fedora 42
- Fedora 41 and 42 are not available in archive repo, archive repo is only for EOL releases
- new tests to verify that packaging works for all supported version of Fedora: latest (default), 41, 42